### PR TITLE
Fix: Use npm install instead of npm ci in Amplify builds

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,7 +3,7 @@ backend:
   phases:
     preBuild:
       commands:
-        - npm ci
+        - npm install
     build:
       commands:
         - "npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID"
@@ -16,7 +16,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm ci
+        - npm install
     build:
       commands:
         - echo "Copying amplify_outputs.json to public directory..."


### PR DESCRIPTION
## Problem
The build keeps failing with missing nested dependencies (fast-xml-parser, strnum, json-schema-to-ts, etc.) even though package-lock.json exists. This happens because `npm ci` requires a perfectly synced lock file, but our nested dependencies have peer dependency conflicts that prevent this.

## Solution  
Changed `amplify.yml` to use `npm install` instead of `npm ci`. This allows npm to resolve dependencies at build time rather than requiring a pre-existing perfect lock file.

## Trade-offs
- ✅ Builds will succeed
- ⚠️ Builds may be slightly slower (npm install vs npm ci)
- ⚠️ Less deterministic (dependencies resolved at build time)

However, this is the only way to get deployments working given the current dependency tree.