### PR TITLE
fix: remove hardcoded resource names to avoid CloudFormation conflicts

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -22,15 +22,18 @@ const graphqlApi = backend.data.resources.graphqlApi;
 const dataStack = backend.data.resources.cfnResources.cfnGraphqlApi.stack;
 
 // Only create email identity if not in sandbox mode
-if (backend.stack.stackName.includes('main-branch')) {
-  new ses.EmailIdentity(dataStack, 'ContactEmail', {
-    identity: ses.Identity.email('hello@elevatorrobot.com'),
-  });
-}
+// SES email identity already deployed - commenting out to avoid conflicts
+// Email hello@elevatorrobot.com is already verified at the account level
+// if (backend.stack.stackName.includes('main-branch')) {
+//   new ses.EmailIdentity(dataStack, 'ContactEmail', {
+//     identity: ses.Identity.email('hello@elevatorrobot.com'),
+//   });
+// }
 
 // Create DynamoDB table for rate limiting in data stack
+// Using dynamic table name to avoid conflicts across deployments
 const rateLimitTable = new dynamodb.Table(dataStack, 'RateLimitTable', {
-  tableName: 'contact-form-rate-limits',
+  // Don't specify tableName - let CDK generate unique name
   partitionKey: {
     name: 'ipAddress',
     type: dynamodb.AttributeType.STRING,
@@ -88,7 +91,8 @@ new MonitoringAlarms(dataStack, 'MonitoringAlarms', {
   graphqlApiId: graphqlApi.apiId,
   rumAppName: 'elevator-robot-website',
   adminEmail: 'hello@elevatorrobot.com',
-  snsTopicName: 'elevator-robot-alarms',
+  // Remove hardcoded SNS topic name to avoid conflicts
+  // snsTopicName: 'elevator-robot-alarms',
 });
 
 export default backend;

--- a/amplify/monitoring/alarms.ts
+++ b/amplify/monitoring/alarms.ts
@@ -68,7 +68,7 @@ export class MonitoringAlarms extends Construct {
     // SNS Topic for Alarm Notifications
     // ========================================
     this.alarmTopic = new sns.Topic(this, 'AlarmTopic', {
-      topicName: snsTopicName,
+      // Don't specify topicName to allow CDK to generate unique names
       displayName: 'Elevator Robot Website Alarms',
     });
 
@@ -105,7 +105,7 @@ export class MonitoringAlarms extends Construct {
     });
 
     this.lambdaErrorAlarm = new cloudwatch.Alarm(this, 'LambdaErrorRateAlarm', {
-      alarmName: 'elevator-robot-lambda-error-rate',
+      // Remove hardcoded alarmName to allow CDK to generate unique names
       alarmDescription: 'Lambda function error rate exceeded 5% threshold',
       metric: lambdaErrorRateMetric,
       threshold: 5,
@@ -136,7 +136,7 @@ export class MonitoringAlarms extends Construct {
     });
 
     this.apiLatencyAlarm = new cloudwatch.Alarm(this, 'ApiLatencyAlarm', {
-      alarmName: 'elevator-robot-api-latency',
+      // Remove hardcoded alarmName to allow CDK to generate unique names
       alarmDescription: 'API Gateway P95 latency exceeded 1000ms threshold',
       metric: apiLatencyP95Metric,
       threshold: 1000,
@@ -182,7 +182,7 @@ export class MonitoringAlarms extends Construct {
     });
 
     this.sesBounceRateAlarm = new cloudwatch.Alarm(this, 'SesBounceRateAlarm', {
-      alarmName: 'elevator-robot-ses-bounce-rate',
+      // Remove hardcoded alarmName to allow CDK to generate unique names
       alarmDescription: 'SES bounce rate exceeded 5% threshold',
       metric: sesBounceRateMetric,
       threshold: 5,
@@ -223,7 +223,7 @@ export class MonitoringAlarms extends Construct {
     });
 
     this.rumJsErrorAlarm = new cloudwatch.Alarm(this, 'RumJsErrorAlarm', {
-      alarmName: 'elevator-robot-rum-js-errors',
+      // Remove hardcoded alarmName to allow CDK to generate unique names
       alarmDescription: 'RUM JavaScript error rate exceeded 10 errors per minute',
       metric: rumJsErrorRateMetric,
       threshold: 10,


### PR DESCRIPTION
## Problem
Amplify deployment was failing with `UPDATE_ROLLBACK_COMPLETE` due to resource conflicts:
- SES email identity `hello@elevatorrobot.com` already exists
- DynamoDB table `contact-form-rate-limits` already exists
- SNS topic `elevator-robot-alarms` already exists
- CloudWatch alarms with hardcoded names already exist

All were using **hardcoded resource names** that conflict across stack deployments.

## Solution
✅ **Commented out SES email identity creation**
   - Email already verified at account level
   - No need to recreate per stack

✅ **Removed hardcoded DynamoDB table name**
   - Let CDK auto-generate unique names
   - Lambda gets table name via environment variable

✅ **Removed hardcoded SNS topic name**
   - CDK generates unique topic names per stack

✅ **Removed hardcoded CloudWatch alarm names**
   - CDK generates unique alarm names per stack

## Impact
- ✅ Deployments will succeed without CloudFormation conflicts
- ✅ All functionality preserved (Lambda gets table name dynamically)
- ✅ No manual AWS Console cleanup required
- ✅ Build passes locally

## Testing
- [x] `npm run build` passes
- [x] TypeScript compilation successful
- [x] No syntax errors

This should fix the Amplify pipeline deployment failure.