### PR TITLE
Replace Twitter/X with LinkedIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,14 +27,6 @@
     <meta property="og:site_name" content="Elevator Robot" />
     <meta property="og:locale" content="en_US" />
     
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content="https://elevatorrobot.com" />
-    <meta name="twitter:title" content="Elevator Robot - Custom Software Development & Cloud Solutions" />
-    <meta name="twitter:description" content="Boutique software studio specializing in custom API development, cloud infrastructure, automation, and scalable digital solutions for enterprise clients." />
-    <meta name="twitter:image" content="https://elevatorrobot.com/twitter-card.png" />
-    <meta name="twitter:creator" content="@elevatorrobot" />
-    
     <!-- Additional SEO -->
     <meta name="application-name" content="Elevator Robot" />
     <meta name="apple-mobile-web-app-title" content="Elevator Robot" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -284,14 +284,14 @@ function App() {
                   </svg>
                 </a>
                 <a
-                  href="https://x.com/aphexlog"
+                  href="https://www.linkedin.com/company/elevatorrobot"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="p-3 bg-white/5 hover:bg-white/10 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  aria-label="Visit Elevator Robot on X (formerly Twitter) (opens in new tab)"
+                  aria-label="Visit Elevator Robot on LinkedIn (opens in new tab)"
                 >
                   <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                   </svg>
                 </a>
               </div>
@@ -397,16 +397,17 @@ function App() {
             </a>
             
             <a 
-              href="https://x.com/aphexlog"
+              href="https://www.linkedin.com/company/elevatorrobot"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center justify-center w-12 h-12 bg-white/5 hover:bg-white/10 backdrop-blur-sm border border-white/10 rounded-xl transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-black"
-              aria-label="Visit Elevator Robot on X (formerly Twitter) (opens in new tab)"
-              onClick={() => recordEvent('external_link_click', { destination: 'twitter', location: 'hero' })}
+              className="flex items-center gap-3 px-6 py-3 bg-white/5 hover:bg-white/10 backdrop-blur-sm border border-white/10 rounded-xl transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-black"
+              aria-label="Visit Elevator Robot on LinkedIn (opens in new tab)"
+              onClick={() => recordEvent('external_link_click', { destination: 'linkedin', location: 'hero' })}
             >
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
               </svg>
+              <span className="font-['Audiowide']">LinkedIn</span>
             </a>
           </div>
         </div>

--- a/src/__tests__/touch-targets.test.ts
+++ b/src/__tests__/touch-targets.test.ts
@@ -87,12 +87,11 @@ describe('Touch Target Size Validation', () => {
     it('should define touch targets for social media links', () => {
       const socialSelectors = [
         'a[href*="github.com"]',
-        'a[href*="x.com"]',
-        'a[href*="twitter.com"]'
+        'a[href*="linkedin.com"]'
       ];
 
       expect(socialSelectors).toContain('a[href*="github.com"]');
-      expect(socialSelectors).toContain('a[href*="x.com"]');
+      expect(socialSelectors).toContain('a[href*="linkedin.com"]');
     });
   });
 
@@ -183,7 +182,7 @@ describe('Touch Target Implementation Checklist', () => {
   it('should cover all social media links', () => {
     const elements = [
       'GitHub links',
-      'X/Twitter links',
+      'LinkedIn links',
       'Email links'
     ];
     expect(elements.length).toBe(3);

--- a/src/index.css
+++ b/src/index.css
@@ -1568,8 +1568,7 @@
 
   /* Social Media Links */
   a[href*="github.com"],
-  a[href*="x.com"],
-  a[href*="twitter.com"] {
+  a[href*="linkedin.com"] {
     min-height: 44px;
     min-width: 44px;
     padding: 12px;
@@ -1952,8 +1951,7 @@
 
   /* Social Links in Hero Section */
   a[href*="github.com"],
-  a[href*="x.com"],
-  a[href*="twitter.com"] {
+  a[href*="linkedin.com"] {
     min-height: 44px;
     min-width: 44px;
     padding: 12px;
@@ -2052,7 +2050,7 @@
 
   /* Mobile Menu Social Links */
   .mobile-menu a[href*="github.com"],
-  .mobile-menu a[href*="x.com"] {
+  .mobile-menu a[href*="linkedin.com"] {
     min-height: 44px;
     min-width: 44px;
     padding: 12px;


### PR DESCRIPTION
## Summary
Replaced Twitter/X social links with LinkedIn for a more professional social media presence.

## Changes Made

### Removed Twitter/X
- ❌ Twitter/X link from mobile menu social section
- ❌ Twitter/X link from hero section
- ❌ Twitter Card meta tags from `index.html`
- ❌ Twitter/X CSS selectors

### Added LinkedIn
- ✅ LinkedIn button in mobile menu (icon only)
- ✅ LinkedIn button in hero section (icon + text label matching GitHub style)
- ✅ LinkedIn CSS selectors for touch targets
- ✅ Updated tests to include LinkedIn

## LinkedIn Buttons

Both LinkedIn buttons link to: `https://www.linkedin.com/company/elevatorrobot`

**Hero Section:** Icon + "LinkedIn" text label (matches GitHub button style)
**Mobile Menu:** Icon only (matches GitHub button style)

## Impact
- More professional B2B-focused social presence
- Consistent button styling across social links
- All touch targets properly sized (44x44px minimum)
- Build succeeds with no errors

## Testing
- [x] Build succeeds (`npm run build`)
- [x] LinkedIn buttons styled consistently
- [x] Touch target tests pass
- [x] No Twitter/X references remain