### PR TITLE
Simplify mobile navigation - show only Let's Talk

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,6 @@ const useScrollReveal = () => {
 function App() {
   const [isContactOpen, setIsContactOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const showContact = false; // Feature flag for contact button
   const { recordEvent } = useRUM();
   
@@ -126,19 +125,6 @@ function App() {
     setIsContactOpen(newState);
     // Track contact form open/close
     recordEvent('contact_form_toggle', { opened: newState });
-  };
-
-  const toggleMobileMenu = () => {
-    const newState = !mobileMenuOpen;
-    setMobileMenuOpen(newState);
-    // Track mobile menu toggle
-    recordEvent('mobile_menu_toggle', { opened: newState });
-  };
-
-  const closeMobileMenu = () => {
-    setMobileMenuOpen(false);
-    // Track mobile menu close
-    recordEvent('mobile_menu_close', {});
   };
 
 
@@ -201,112 +187,11 @@ function App() {
             )}
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            onClick={toggleMobileMenu}
-            className="md:hidden p-2 text-white hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded transition-colors"
-            aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-            aria-expanded={mobileMenuOpen}
-          >
-            {mobileMenuOpen ? (
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            ) : (
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            )}
-          </button>
-        </div>
-
-        {/* Mobile Menu Slide-in */}
-        <div
-          className={`md:hidden fixed inset-y-0 right-0 w-64 bg-black/95 backdrop-blur-xl border-l border-white/10 shadow-2xl transform transition-transform duration-300 ease-in-out z-50 ${
-            mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
-          }`}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Mobile navigation menu"
-        >
-          <div className="flex flex-col h-full p-6">
-            <div className="flex justify-between items-center mb-8">
-              <h2 className="text-xl font-bold gradient-text font-['Audiowide']">Menu</h2>
-              <button
-                onClick={closeMobileMenu}
-                className="p-2 text-gray-400 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-                aria-label="Close menu"
-              >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            <nav className="flex flex-col gap-4">
-              <a
-                href="#services"
-                onClick={closeMobileMenu}
-                className="text-lg text-white hover:text-blue-400 transition-colors py-3 px-4 rounded-lg hover:bg-white/5 font-['Audiowide'] focus:outline-none focus:ring-2 focus:ring-blue-500"
-                aria-label="Navigate to Services section"
-              >
-                Services
-              </a>
-              <a
-                href="#about"
-                onClick={closeMobileMenu}
-                className="text-lg text-white hover:text-blue-400 transition-colors py-3 px-4 rounded-lg hover:bg-white/5 font-['Audiowide'] focus:outline-none focus:ring-2 focus:ring-blue-500"
-                aria-label="Navigate to About section"
-              >
-                About
-              </a>
-              <a
-                href="#contact"
-                onClick={closeMobileMenu}
-                className="text-lg text-white hover:text-blue-400 transition-colors py-3 px-4 rounded-lg hover:bg-white/5 font-['Audiowide'] focus:outline-none focus:ring-2 focus:ring-blue-500"
-                aria-label="Navigate to Contact section"
-              >
-                Contact
-              </a>
-            </nav>
-
-            <div className="mt-auto pt-6 border-t border-white/10">
-              <div className="flex gap-4 justify-center">
-                <a
-                  href="https://github.com/Elevator-Robot"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="p-3 bg-white/5 hover:bg-white/10 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  aria-label="Visit Elevator Robot on GitHub (opens in new tab)"
-                >
-                  <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                  </svg>
-                </a>
-                <a
-                  href="https://www.linkedin.com/company/elevatorrobot"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="p-3 bg-white/5 hover:bg-white/10 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  aria-label="Visit Elevator Robot on LinkedIn (opens in new tab)"
-                >
-                  <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                  </svg>
-                </a>
-              </div>
-            </div>
+          {/* Mobile Navigation - Only "Let's Talk" */}
+          <div className="md:hidden">
+            <a href="#contact" className="link-underline font-['Audiowide'] text-sm" aria-label="Navigate to Contact section">Let's Talk</a>
           </div>
         </div>
-
-        {/* Mobile Menu Overlay */}
-        {mobileMenuOpen && (
-          <div
-            className="md:hidden fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
-            onClick={closeMobileMenu}
-            aria-hidden="true"
-          />
-        )}
       </nav>
 
       {/* Main Content */}


### PR DESCRIPTION
## Changes
- **Desktop**: Shows all 3 navigation links (Services, About, Let's Talk)
- **Mobile**: Shows only 'Let's Talk' button (no hamburger menu)

## Removed (~118 lines)
- Mobile hamburger menu button and slide-in panel
- Mobile menu overlay
- `mobileMenuOpen` state
- `toggleMobileMenu` and `closeMobileMenu` functions
- Mobile menu with Services/About/Contact links
- Mobile menu social icons section

## Added (3 lines)
- Simple 'Let's Talk' link for mobile viewport

## Result
- Cleaner mobile navigation experience
- Desktop users see full navigation
- Mobile users have quick access to contact
- Users can scroll through all sections naturally
- Build succeeds ✅

**Lines changed:** +3/-118