### PR TITLE
Fix contact section links alignment

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2020,7 +2020,9 @@
     padding: 12px 16px;
     display: flex;
     align-items: center;
+    justify-content: flex-start; /* Explicitly left-align */
     gap: 12px;
+    width: fit-content; /* Shrink to content width */
   }
 
   /* Contact Form Popup Close Button */


### PR DESCRIPTION
Fixed contact section email and GitHub links on mobile viewport.

Issues Fixed:
- GitHub link appeared centered instead of left-aligned like email
- Extra clickable space around links

Solution:
- Added justify-content: flex-start to explicitly left-align content
- Added width: fit-content to shrink link to content width only

Result:
- Both email and GitHub links now left-aligned
- Links only clickable on actual content
- Better mobile UX with precise touch targets
- Build succeeds